### PR TITLE
Fix "has-block-and-has-block-params" deprecation

### DIFF
--- a/addon/templates/components/route.hbs
+++ b/addon/templates/components/route.hbs
@@ -5,7 +5,7 @@
   )
   as |RouteComponent|
 }}
-  {{#if hasBlock}}
+  {{#if (has-block)}}
 
     {{yield (hash
       inDOM=this.inDOM


### PR DESCRIPTION
The change fixes [has-block-and-has-block-params](https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params) deprecation